### PR TITLE
add libogre-1.12 entry

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4165,6 +4165,11 @@ libogre:
   opensuse: [ogre-devel]
   slackware: [ogre]
   ubuntu: [libogre-1.9.0v5]
+libogre-1.12-dev:
+  debian:
+    bullseye: [libogre-1.12-dev]
+  ubuntu:
+    jammy: [libogre-1.12-dev]
 libogre-dev:
   arch: [ogre-1.9]
   debian:
@@ -4186,11 +4191,6 @@ libogre1.12.10:
     bullseye: [libogre1.12.10]
   ubuntu:
     jammy: [libogre1.12.10]
-libogre-1.12-dev:
-  debian:
-    bullseye: [libogre-1.12-dev]
-  ubuntu:
-    jammy: [libogre-1.12-dev]
 libois-dev:
   arch: [ois]
   debian: [libois-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4181,7 +4181,16 @@ libogre-dev:
   opensuse: [libOgreMain-devel, libOgreOverlay-devel, libOgrePaging-devel, libOgreProperty-devel, libOgreRTShaderSystem-devel, libOgreTerrain-devel, libOgreVolume-devel]
   slackware: [ogre]
   ubuntu: [libogre-1.9-dev]
-libogre-1.12:
+libogre1.12.10:
+  debian:
+    bullseye: [libogre1.12.10]
+  ubuntu:
+    jammy: [libogre1.12.10]
+libogre-1.12-dev:
+  debian:
+    bullseye: [libogre-1.12-dev]
+  ubuntu:
+    jammy: [libogre-1.12-dev]
 libois-dev:
   arch: [ois]
   debian: [libois-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4169,6 +4169,7 @@ libogre-1.12-dev:
   debian:
     bullseye: [libogre-1.12-dev]
   ubuntu:
+    focal: [libogre-1.12-dev]
     jammy: [libogre-1.12-dev]
 libogre-dev:
   arch: [ogre-1.9]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4181,6 +4181,7 @@ libogre-dev:
   opensuse: [libOgreMain-devel, libOgreOverlay-devel, libOgrePaging-devel, libOgreProperty-devel, libOgreRTShaderSystem-devel, libOgreTerrain-devel, libOgreVolume-devel]
   slackware: [ogre]
   ubuntu: [libogre-1.9-dev]
+libogre-1.12:
 libois-dev:
   arch: [ois]
   debian: [libois-dev]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libogre1.12.10
libogre-1.12-dev

## Package Upstream Source:

https://github.com/OGRECave/ogre

## Purpose of using this:

This dependency is a newer version for the existing libogre library (which should have been called libogre-1.9 and libogre-1.9-dev). It will be used in RViz as a replacement of the currently used ogre_rviz_vendor package. 

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian (bullseye):
   - https://packages.debian.org/bullseye/libogre1.12.10
   - https://packages.debian.org/bullseye/libogre-1.12-dev
- Ubuntu:
   - https://packages.ubuntu.com/jammy/libogre1.12.10 (Jammy ONLY)
   - https://packages.ubuntu.com/jammy/libogre-1.12-dev (Focal, Jammy)
- Fedora: https://packages.fedoraproject.org/
  - Not Available
- Arch: https://www.archlinux.org/packages/
  - Not Available (but v13.4.1 is available, what should we do? : https://archlinux.org/packages/community/x86_64/ogre/)
- Gentoo: https://packages.gentoo.org/
  - Not Available
- macOS: https://formulae.brew.sh/
  - Not Available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not Available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not Available
- openSUSE: https://software.opensuse.org/package/
  - Not Available (but v13.3.4 is available, what should we do? : https://build.opensuse.org/package/show/openSUSE%3AFactory/ogre)
